### PR TITLE
strip extraneous whitespace so I can send stats with bash

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -123,7 +123,7 @@ module StatsD
   end
 
   def receive_data(packet)
-    bits = packet.split(":")
+    bits = packet.strip.split(":")
     key = bits.shift.gsub(/\s+/, "_") \
                     .gsub(/\//, "-") \
                     .gsub(/[^a-zA-Z_\-0-9\.]/, "")


### PR DESCRIPTION
Without this, the following breaks because of the trailing newline from the echo:
echo "blah:1|c" | nc -w 1 -u localhost 8125
