### PR TITLE
report stats_counts for counters

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -194,6 +194,7 @@ module StatsD
       @@counters.each do |key, value|
         suffix = @@key_suffix ? ".#{@@key_suffix}" : ""
         updates << "stats.#{key}#{suffix} #{value / @@flush_interval} #{now}"
+        updates << "stats_counts.#{key}#{suffix} #{value} #{now}"
       end
 
       @@counters.each { |k, v| @@counters[k] = 0 }


### PR DESCRIPTION
statsd now reports stats_counts in addition to stats for counters.

This is the raw number of counts that occurred within a flush interval.

This functionality has been added in etsy/statsd in April 2011:
https://github.com/etsy/statsd/commit/3bf378684f2e4e7107ee112d34fae40c3ee6062a
